### PR TITLE
ID-1390 [Fix] Ensure list fields are correctly validated

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -2580,7 +2580,7 @@ VeeValidate.extend('required', {
         name: this.name
       });
 
-      field.value = newValue; // Ensure list values are revalidated after a change is detected
+      field.value = newValue; // Ensure model-less values are manually validated after change
 
       if (this.type === 'list') {
         this.$refs.provider.validate(newValue);
@@ -2805,7 +2805,11 @@ VeeValidate.extend('required', {
     }
   },
   mounted: function mounted() {
-    this.initProvider();
+    this.initProvider(); // Ensure model-less values are synced with the validation provider
+
+    if (this.type === 'list') {
+      this.$refs.provider.syncValue(this.value);
+    }
 
     if (this.ready) {
       var ready = new Function(this.ready)();

--- a/src/components/Field.vue
+++ b/src/components/Field.vue
@@ -245,7 +245,7 @@ export default {
 
       field.value = newValue;
 
-      // Ensure list values are revalidated after a change is detected
+      // Ensure model-less values are manually validated after change
       if (this.type === 'list') {
         this.$refs.provider.validate(newValue);
       }
@@ -451,6 +451,11 @@ export default {
   },
   mounted() {
     this.initProvider();
+
+    // Ensure model-less values are synced with the validation provider
+    if (this.type === 'list') {
+      this.$refs.provider.syncValue(this.value);
+    }
 
     if (this.ready) {
       const ready = new Function(this.ready)();


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1390

VeeValidate by default uses inputs or models to track the value for each validator.

When the component doesn't use either (e.g. the list field), this needs to be manually tracked.