### PR TITLE
ID-712 [Fix] Ensures initial dropdown value is set

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -2574,13 +2574,7 @@ VeeValidate.extend('required', {
         return;
       }
 
-      this.$parent.$parent.fields[this.name] = newValue;
-
-      var field = _.find(this.$parent.$parent.configuration.fields, {
-        name: this.name
-      });
-
-      field.value = newValue; // Ensure model-less values are manually validated after change
+      this.updateParentValue(newValue); // Ensure model-less values are manually validated after change
 
       if (this.type === 'list') {
         this.$refs.provider.validate(newValue);
@@ -2605,6 +2599,15 @@ VeeValidate.extend('required', {
       }
 
       return this.value;
+    },
+    updateParentValue: function updateParentValue(value) {
+      this.$parent.$parent.fields[this.name] = value;
+
+      var field = _.find(this.$parent.$parent.configuration.fields, {
+        name: this.name
+      });
+
+      field.value = value;
     },
     onListValueChanged: function onListValueChanged(name) {
       if (name === this.headingFieldName) {
@@ -2809,6 +2812,8 @@ VeeValidate.extend('required', {
 
     if (this.type === 'list') {
       this.$refs.provider.syncValue(this.value);
+    } else if (this.type === 'dropdown' && typeof this.value === 'undefined') {
+      this.updateParentValue('');
     }
 
     if (this.ready) {

--- a/src/components/Field.vue
+++ b/src/components/Field.vue
@@ -239,11 +239,7 @@ export default {
         return;
       }
 
-      this.$parent.$parent.fields[this.name] = newValue;
-
-      const field = _.find(this.$parent.$parent.configuration.fields, { name: this.name });
-
-      field.value = newValue;
+      this.updateParentValue(newValue);
 
       // Ensure model-less values are manually validated after change
       if (this.type === 'list') {
@@ -271,6 +267,13 @@ export default {
       }
 
       return this.value;
+    },
+    updateParentValue(value) {
+      this.$parent.$parent.fields[this.name] = value;
+
+      const field = _.find(this.$parent.$parent.configuration.fields, { name: this.name });
+
+      field.value = value;
     },
     onListValueChanged(name) {
       if (name === this.headingFieldName) {
@@ -455,6 +458,8 @@ export default {
     // Ensure model-less values are synced with the validation provider
     if (this.type === 'list') {
       this.$refs.provider.syncValue(this.value);
+    } else if (this.type === 'dropdown' && typeof this.value === 'undefined') {
+      this.updateParentValue('');
     }
 
     if (this.ready) {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-712

When the dropdown value is `undefined`, it doesn't select the default value. We're giving it a `""` value instead to select the initial "Select an option" option.

Follows https://github.com/Fliplet/fliplet-widget-helper-configuration/pull/21