### PR TITLE
ID-1406 [Fix] Allow fullscreen providers to save before validation starts

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -589,16 +589,7 @@ __webpack_require__.r(__webpack_exports__);
                 return _context.abrupt("return");
 
               case 4:
-                if (!window.currentProvider) {
-                  _context.next = 7;
-                  break;
-                }
-
-                window.currentProvider.forwardSaveRequest();
-                return _context.abrupt("return");
-
-              case 7:
-                _context.next = 9;
+                _context.next = 6;
                 return Promise.all(_this.$refs.fieldInstances.map(function (field) {
                   if (field.show === false) {
                     delete _this.fields[field.name];
@@ -608,7 +599,7 @@ __webpack_require__.r(__webpack_exports__);
                   return field.onSubmit();
                 }));
 
-              case 9:
+              case 6:
                 if (_this.configuration.beforeSave) {
                   beforeSaveFunction = new Function(_this.configuration.beforeSave)();
 
@@ -659,7 +650,7 @@ __webpack_require__.r(__webpack_exports__);
                   });
                 });
 
-              case 12:
+              case 9:
               case "end":
                 return _context.stop();
             }
@@ -672,6 +663,11 @@ __webpack_require__.r(__webpack_exports__);
     var _this2 = this;
 
     Fliplet.Widget.onSaveRequest(function () {
+      if (window.currentProvider) {
+        window.currentProvider.forwardSaveRequest();
+        return;
+      }
+
       return _this2.$refs.observer.validate().then(function (valid) {
         return _this2.onSubmit(valid);
       });
@@ -2611,7 +2607,7 @@ VeeValidate.extend('required', {
 
 
       if (this.validate) {
-        var name = "validate-".concat(this.name);
+        var name = "validate-".concat(this.fieldName);
         var validate = new Function(this.validate)();
         VeeValidate.extend(name, validate);
         rules[name] = true;
@@ -2806,6 +2802,7 @@ VeeValidate.extend('required', {
 
           _this3.openProvider();
 
+          Fliplet.Widget.setSaveButtonLabel('Save');
           window.currentProvider = _this3.provider;
         });
         this.eventsBound = true;
@@ -2853,6 +2850,7 @@ VeeValidate.extend('required', {
             delete window.currentProvider;
             delete _this4.provider;
             _this4.providerPromise = undefined;
+            Fliplet.Widget.resetSaveButtonLabel();
 
             _this4.initProvider();
           }

--- a/src/Application.vue
+++ b/src/Application.vue
@@ -76,12 +76,6 @@ export default {
         return;
       }
 
-      if (window.currentProvider) {
-        window.currentProvider.forwardSaveRequest();
-
-        return;
-      }
-
       var beforeSave;
 
       await Promise.all(this.$refs.fieldInstances.map((field) => {
@@ -145,6 +139,12 @@ export default {
   },
   mounted() {
     Fliplet.Widget.onSaveRequest(() => {
+      if (window.currentProvider) {
+        window.currentProvider.forwardSaveRequest();
+
+        return;
+      }
+
       return this.$refs.observer.validate()
         .then((valid) => {
           return this.onSubmit(valid);

--- a/src/components/Field.vue
+++ b/src/components/Field.vue
@@ -396,6 +396,7 @@ export default {
         $provider.find('[data-open-provider]').click((event) => {
           event.preventDefault();
           this.openProvider();
+          Fliplet.Widget.setSaveButtonLabel('Save');
           window.currentProvider = this.provider;
         });
 
@@ -449,6 +450,8 @@ export default {
             delete this.provider;
 
             this.providerPromise = undefined;
+
+            Fliplet.Widget.resetSaveButtonLabel();
 
             this.initProvider();
           }

--- a/src/components/Field.vue
+++ b/src/components/Field.vue
@@ -224,7 +224,7 @@ export default {
       // Use custom validate function as custom validation rule
       // https://vee-validate.logaretm.com/v3/guide/basics.html#rule-arguments
       if (this.validate) {
-        const name = `validate-${this.name}`;
+        const name = `validate-${this.fieldName}`;
         const validate = new Function(this.validate)();
 
         VeeValidate.extend(name, validate);


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1406

Validation was happening before fullscreen providers are saved. This meant that if there are fields in that background that aren't valid, the fullscreen provider doesn't save or get dismissed. This user is then stuck with the fullscreen provider.