### PR TITLE
ID-3627 [Fix] Prevent looking up helper instances via API when editing legacy helper components

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -3063,7 +3063,7 @@ function setFieldProperty(fieldName, prop, value) {
 
 Fliplet.Helper.find = function (predicate) {
   // Allow async find for widget instances
-  if (data.id) {
+  if (typeof data.id === 'number') {
     return Fliplet.API.request({
       url: 'v1/apps/' + Fliplet.Env.get('appId') + '/pages/' + Fliplet.Env.get('pageId') + '/helper-instances'
     }).then(function (response) {
@@ -3082,7 +3082,7 @@ Fliplet.Helper.find = function (predicate) {
 
 Fliplet.Helper.findOne = function (predicate) {
   // Allow async find for widget instances
-  if (data.id) {
+  if (typeof data.id === 'number') {
     return Fliplet.Helper.find(predicate).then(function (results) {
       return _.first(results);
     });

--- a/src/libs/lookups.js
+++ b/src/libs/lookups.js
@@ -97,7 +97,7 @@ export function setFieldProperty(fieldName, prop, value) {
  */
 Fliplet.Helper.find = function(predicate) {
   // Allow async find for widget instances
-  if (data.id) {
+  if (typeof data.id === 'number') {
     return Fliplet.API.request({
       url: 'v1/apps/' + Fliplet.Env.get('appId') + '/pages/' + Fliplet.Env.get('pageId') + '/helper-instances'
     }).then(function(response) {
@@ -115,7 +115,7 @@ Fliplet.Helper.find = function(predicate) {
  */
 Fliplet.Helper.findOne = function(predicate) {
   // Allow async find for widget instances
-  if (data.id) {
+  if (typeof data.id === 'number') {
     return Fliplet.Helper.find(predicate).then(function(results) {
       return _.first(results);
     });


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-3627